### PR TITLE
fix #25 

### DIFF
--- a/VBA_check.m
+++ b/VBA_check.m
@@ -103,12 +103,10 @@ u = VBA_getU(u,options,dim,'2macro');
 
 %% ________________________________________________________________________
 %  check priors
-if ~isfield(options,'priors')
-    priors = [];
-else
-    priors = options.priors;
-end
-[priors,options.params2update] = VBA_fillInPriors(priors,dim,options.verbose);
+[options,options.params2update] = VBA_fillInPriors(dim,options);
+priors = options.priors;
+
+% TODO remove the two tests below as they should be already taken care of
 if options.binomial
     priors = rmfield(priors,{'a_sigma','b_sigma'});
 end

--- a/VBA_fillInPriors.m
+++ b/VBA_fillInPriors.m
@@ -1,4 +1,4 @@
-function [priors,params2update] = VBA_fillInPriors(priors,dim,verbose)
+function [options,params2update] = VBA_fillInPriors(dim,options)
 % fills in priors structure with default priors if necessary
 % function [priors,params2update] = VBA_fillInPriors(priors,dim,verbose)
 % IN: [see VBA_check.m]
@@ -15,60 +15,13 @@ params2update.x0 = 1:dim.n;
 for t=1:dim.n_t
     params2update.x{t} = 1:dim.n;
 end
-if ~isempty(priors)
-    % Get user-specified priors
-    fn = fieldnames(priors);
-    priors0 = VBA_priors(dim,struct('binomial',0));
-    fn0 = fieldnames(priors0);
-    io = ismember(fn0,fn);
-    ind = find(io==0);
-    if ~isempty(ind)
-        VBA_disp('Warning: could not find priors:',struct('verbose',verbose))
-        for i = 1:length(ind)
-            VBA_disp(['      - ',fn0{ind(i)}],struct('verbose',verbose));
-            eval(['priors.',fn0{ind(i)},'=priors0.',fn0{ind(i)},';',])
-        end
-        VBA_disp('---> Using default (non-informative) priors',struct('verbose',verbose))
-    end
-    % check dimension and infinite precision priors
-    if dim.n_theta > 0 % This finds which evolution params to update
-        dpc = diag(priors.SigmaTheta);
-        iz = find(dpc==0);
-        if ~isempty(iz)
-            params2update.theta = setdiff(1:dim.n_theta,iz);
-        end
-    end
-    if dim.n_phi > 0 % This finds which observation params to update
-        dpc = diag(priors.SigmaPhi);
-        iz = find(dpc==0);
-        if ~isempty(iz)
-            params2update.phi = setdiff(1:dim.n_phi,iz);
-        end
-    end
-    if dim.n > 0  % This finds which initial conditions to update
-        dpc = diag(priors.SigmaX0);
-        iz = find(dpc==0);
-        if ~isempty(iz)
-            params2update.x0 = setdiff(1:dim.n,iz);
-        end
-        for t=1:dim.n_t
-            dpc = diag(priors.iQx{t});
-            iz = find(isinf(dpc));
-            if ~isempty(iz)
-                params2update.x{t} = setdiff(1:dim.n,iz);
-            end
-        end
-    end
-    % insure vertical priors
-    priors.muPhi = priors.muPhi(:);
-    priors.muTheta = priors.muTheta(:);
-    priors.muX0 = priors.muX0(:);
-    if isfield(priors,'a_sigma')
-        priors.a_sigma = priors.a_sigma(:);
-        priors.b_sigma = priors.b_sigma(:);
-    end
-    
-else % Build default (non-informative) priors
-    priors = VBA_priors(dim,struct('binomial',0));
+
+
+default_priors = VBA_priors(dim,options);
+if ~isfield(options,'priors')
+    options.priors = struct();
 end
+
+options.priors = check_struct(options.priors,default_priors);
+
 

--- a/VBA_hyperparameters.m
+++ b/VBA_hyperparameters.m
@@ -51,12 +51,9 @@ end
 VBA_disp('--- VBA with hyperparameters adjustment... ---',options)
 
 % Initialize priors
-try
-    priors = options.priors;
-catch
-    priors = [];
-end
-[options.priors,params2update] = VBA_fillInPriors(priors,dim,options.verbose);
+[options,params2update] = VBA_fillInPriors(dim,options);
+
+
 nphi = 0;
 ntheta = 0;
 nx0 = 0;


### PR DESCRIPTION
VBA_fillInPriors now makes use of VBA_priors to set default priors. This
- make sure the default priors take the sources definition into account
- ensure that default priors are the same irrespective of if an initial prior structure is given or not
