### PR TITLE
Fix bernoulli.m clashing with Sym

### DIFF
--- a/subfunctions/VBA_bernoulli.m
+++ b/subfunctions/VBA_bernoulli.m
@@ -1,4 +1,4 @@
-function y=bernoulli(p,n)
+function y=VBA_bernoulli(p,n)
 % BERNOULLI.M
 %bernoulli(p,n)
 % This function generates n independent draws of a Bernoulli

--- a/subfunctions/demo_influenceLearning.m
+++ b/subfunctions/demo_influenceLearning.m
@@ -29,7 +29,7 @@ x0 = [0]; % log-odds of P(o=1)
 theta = [1;1;0]; % weight (PE1), weight (PE2), opponent's temp
 phi = [-1;0]; % (log-) temperature, bias
 N = 50; % number of trials
-o = bernoulli(.75,N)'; % opponent's choices (here dummy binomial sampling)
+o = VBA_bernoulli(.75,N)'; % opponent's choices (here dummy binomial sampling)
 a = NaN(1,N);
 gx = NaN(1,N);
 x = zeros(dim.n,N+1);

--- a/subfunctions/demo_recur.m
+++ b/subfunctions/demo_recur.m
@@ -31,7 +31,7 @@ if diluteP==1
     theta = [theta;-log(2)];
 end
 N = 50; % number of trials
-o = bernoulli(.65,N)'; % opponent's choices (here dummy binomial sampling)
+o = VBA_bernoulli(.65,N)'; % opponent's choices (here dummy binomial sampling)
 tic
 a = NaN(1,N); % agent's choices
 gx = NaN(1,N);

--- a/subfunctions/script_test_rec.m
+++ b/subfunctions/script_test_rec.m
@@ -3,7 +3,7 @@
 %%%%% (should be analytically equivalent but not numerically). Small
 %%%%% deiations for 2-ToM (but accumulates) larger for 3-ToM
 x=zeros(2,101); xtest=x;
-y1=bernoulli(.7,100);
+y1=VBA_bernoulli(.7,100);
 inF.player=1;
 inF.lev=0;
 Par=0; %theta
@@ -14,7 +14,7 @@ end
 %%
 N=1000
 xtest=zeros(8,N+1); x=zeros(9,N+1);
-y1=bernoulli(.7,N);y2=bernoulli(.5,N);
+y1=VBA_bernoulli(.7,N);y2=VBA_bernoulli(.5,N);
 HS=cat(3,[1,0;0,1],[0,1;1,0]);
 inF.player=1;
 inF.lev=1;
@@ -37,7 +37,7 @@ find(abs(xcomp-xtest)>1e-15)
 %%
 N=50;
 
-y1=bernoulli(.7,100);y2=bernoulli(.5,100);
+y1=VBA_bernoulli(.7,100);y2=VBA_bernoulli(.5,100);
 %%
 xtest=zeros(23,N+1); x=zeros(26,N+1);
 HS=cat(3,[1,0;0,1],[0,1;1,0]);
@@ -62,7 +62,7 @@ find(abs(xcomp-xtest)>1e-5)
 %%
 N=50;
 xtest=zeros(53,N+1); x=zeros(60,N+1);
-y1=bernoulli(.7,100);y2=bernoulli(.5,100);
+y1=VBA_bernoulli(.7,100);y2=VBA_bernoulli(.5,100);
 HS=cat(3,[1,0;0,1],[0,1;1,0]);
 inF.player=1;
 inF.lev=3;
@@ -89,7 +89,7 @@ N=10;
 inF.lev=7;
 %xtest=zeros(53,N+1); 
 x=zeros(sizeXrec(inF.lev,2),N+1);
-y1=bernoulli(.7,100);y2=bernoulli(.5,100);
+y1=VBA_bernoulli(.7,100);y2=VBA_bernoulli(.5,100);
 HS=cat(3,[1,0;0,1],[0,1;1,0]);
 inF.player=1;
 
@@ -113,7 +113,7 @@ end
 %%
 N=100;
  x=zeros(264,N+1);
-y1=bernoulli(.7,100);y2=bernoulli(.5,100);
+y1=VBA_bernoulli(.7,100);y2=VBA_bernoulli(.5,100);
 HS=cat(3,[1,0;0,1],[0,1;1,0]);
 inF.player=1;
 inF.lev=5;


### PR DESCRIPTION
The symbolic toolbox has a bernoulli function which clashes with VBA's. This fix renames VBA's bernoulli.m file to VBA_bernoulli.m and updates references to bernoulli.m to reference the new function name.