### PR TITLE
uncommented multisession fixed.X0

### DIFF
--- a/core/VBA_multisession_expand.m
+++ b/core/VBA_multisession_expand.m
@@ -69,11 +69,11 @@ fixed = VBA_check_struct(options.multisession.fixed, ...
 % syntactic sugar handling 
 if isequal(fixed.theta ,'all'), fixed.theta = 1:dim.n_theta; end
 if isequal(fixed.phi   ,'all'), fixed.phi   = 1:dim.n_phi; end
-%if isequal(fixed.X0    ,'all'), fixed.X0    = 1:dim.n; end
+if isequal(fixed.X0    ,'all'), fixed.X0    = 1:dim.n; end
     
 theta_multi = setdiff(theta_multi,fixed.theta);
 phi_multi   = setdiff(phi_multi  ,fixed.phi  );
-%X0_multi    = setdiff(X0_multi   ,fixed.X0   );
+X0_multi    = setdiff(X0_multi   ,fixed.X0   );
 
 % = expand (duplicate) priors and dimensions to cover all sessions
 priors = options.priors;


### PR DESCRIPTION
You might have accidentally left fixing X0 across sessions commented out when debugging? When I comment the two lines back in it works again. 